### PR TITLE
Remove the usage of rustc-serialize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "servo-websocket"
-version = "0.20.0"
+version = "0.20.1"
 authors = ["cyderize <admin@cyderize.org>"]
 
 description = "A WebSocket (RFC6455) library for Rust."
@@ -21,11 +21,14 @@ hyper = "0.10"
 unicase = "1.0.1"
 openssl = "0.9"
 url = "1.0"
-rustc-serialize = "0.3.16"
 bitflags = "1.0"
 rand = "0.3.12"
 byteorder = "1.0"
 net2 = "0.2.17"
+base64 = "0.6"
+
+[dev-dependencies]
+serde_json = "1"
 
 [features]
 nightly = ["hyper/nightly"]

--- a/examples/autobahn-client.rs
+++ b/examples/autobahn-client.rs
@@ -1,11 +1,10 @@
 extern crate websocket;
-extern crate rustc_serialize as serialize;
+extern crate serde_json;
 
 use std::str::from_utf8;
 use websocket::client::request::Url;
 use websocket::{Client, Message, Sender, Receiver};
 use websocket::message::Type;
-use serialize::json;
 
 fn main() {
 	let addr = "ws://127.0.0.1:9001".to_string();
@@ -99,7 +98,7 @@ fn get_case_count(addr: String) -> usize {
 		};
 		match message.opcode {
 			Type::Text => {
-				count = json::decode(from_utf8(&*message.payload).unwrap()).unwrap();
+				count = serde_json::from_str(from_utf8(&*message.payload).unwrap()).unwrap();
 				println!("Will run {} cases...", count);
 			}
 			Type::Close => {

--- a/src/header/accept.rs
+++ b/src/header/accept.rs
@@ -3,7 +3,7 @@ use hyper::header::parsing::from_one_raw_str;
 use hyper;
 use std::fmt::{self, Debug};
 use std::str::FromStr;
-use serialize::base64::{ToBase64, FromBase64, STANDARD};
+use base64;
 use header::WebSocketKey;
 use openssl::hash::{self, hash};
 use result::{WebSocketResult, WebSocketError};
@@ -24,7 +24,7 @@ impl FromStr for WebSocketAccept {
 	type Err = WebSocketError;
 
 	fn from_str(accept: &str) -> WebSocketResult<WebSocketAccept> {
-		match accept.from_base64() {
+		match base64::decode(accept) {
 			Ok(vec) => {
 				if vec.len() != 20 {
 					return Err(WebSocketError::ProtocolError(
@@ -65,7 +65,7 @@ impl WebSocketAccept {
 	/// Return the Base64 encoding of this WebSocketAccept
 	pub fn serialize(&self) -> String {
 		let WebSocketAccept(accept) = *self;
-		accept.to_base64(STANDARD)
+		base64::encode(&accept)
 	}
 }
 

--- a/src/header/key.rs
+++ b/src/header/key.rs
@@ -5,7 +5,7 @@ use std::fmt::{self, Debug};
 use rand;
 use std::mem;
 use std::str::FromStr;
-use serialize::base64::{ToBase64, FromBase64, STANDARD};
+use base64;
 use result::{WebSocketResult, WebSocketError};
 
 /// Represents a Sec-WebSocket-Key header.
@@ -22,7 +22,7 @@ impl FromStr for WebSocketKey {
 	type Err = WebSocketError;
 
 	fn from_str(key: &str) -> WebSocketResult<WebSocketKey> {
-		match key.from_base64() {
+		match base64::decode(key) {
 			Ok(vec) => {
 				if vec.len() != 16 {
 					return Err(WebSocketError::ProtocolError(
@@ -34,7 +34,7 @@ impl FromStr for WebSocketKey {
 				for i in array.iter_mut() {
 					*i = iter.next().unwrap();
 				}
-				
+
 				Ok(WebSocketKey(array))
 			}
 			Err(_) => {
@@ -60,7 +60,7 @@ impl WebSocketKey {
 	/// Return the Base64 encoding of this WebSocketKey
 	pub fn serialize(&self) -> String {
 		let WebSocketKey(key) = *self;
-		key.to_base64(STANDARD)
+        base64::encode(&key)
 	}
 }
 
@@ -88,11 +88,11 @@ mod tests {
 	#[test]
 	fn test_header_key() {
 		use header::Headers;
-		
+
 		let extensions = WebSocketKey([65; 16]);
 		let mut headers = Headers::new();
 		headers.set(extensions);
-		
+
 		assert_eq!(&headers.to_string()[..], "Sec-WebSocket-Key: QUFBQUFBQUFBQUFBQUFBQQ==\r\n");
 	}
 	#[bench]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,10 +35,10 @@
 extern crate hyper;
 extern crate unicase;
 extern crate url;
-extern crate rustc_serialize as serialize;
 extern crate openssl;
 extern crate rand;
 extern crate byteorder;
+extern crate base64;
 
 #[macro_use]
 extern crate bitflags;


### PR DESCRIPTION
It's been deprecated for a while now...
Use base64 and serde_json instead.

The version of base64 isn't the latest to match the one used in servo.